### PR TITLE
feat(utils): add RFC7807 and success response generators :rocket:

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+APP_DEBUG=false
+ERROR_BASE_URL=https://api.domain.com/errors

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Node
+node_modules/
+package-lock.json
+
+# Enviroment
+.env
+
+# OS
+.DS_Store
+Thumbs.db
+**/.DS_Store

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
   "bugs": {
     "url": "https://github.com/NeaDigitra/API-Standard-RFC7807/issues"
   },
-  "homepage": "https://github.com/NeaDigitra/API-Standard-RFC7807#readme"
+  "homepage": "https://github.com/NeaDigitra/API-Standard-RFC7807#readme",
+  "dependencies": {
+    "dotenv": "^17.0.1"
+  }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,5 @@
+require('dotenv').config({ debug: process.env.APP_DEBUG })
+
+module.exports = {
+  errorBaseUrl: process.env.ERROR_BASE_URL || 'https://api.domain.com/errors'
+}

--- a/src/utils/sendProblem.js
+++ b/src/utils/sendProblem.js
@@ -1,4 +1,5 @@
 const errorMap = require('../errorsMap')
+const { errorBaseUrl } = require('../config')
 
 /**
  * RFC7807 Problem Details Response  
@@ -6,7 +7,7 @@ const errorMap = require('../errorsMap')
  */
 function sendProblem(response, status, errorKey, detail = '', instance = '', errors = null) {
   const err = errorMap[errorKey] || { title: 'Error', status, detail: '', solution: '', example: {} }
-  const type = `https://api.domain.com/errors/${errorKey}`
+  const type = `${errorBaseUrl}/${errorKey}`
   return response.status(status).json({
     type,
     title: err.title,

--- a/src/utils/sendProblem.js
+++ b/src/utils/sendProblem.js
@@ -1,0 +1,20 @@
+const errorMap = require('../errorsMap')
+
+/**
+ * RFC7807 Problem Details Response  
+ * Params: Response, Status, ErrorKey, Detail, Instance, Errors  
+ */
+function sendProblem(response, status, errorKey, detail = '', instance = '', errors = null) {
+  const err = errorMap[errorKey] || { title: 'Error', status, detail: '', solution: '', example: {} }
+  const type = `https://api.domain.com/errors/${errorKey}`
+  return response.status(status).json({
+    type,
+    title: err.title,
+    status,
+    detail: detail || err.detail,
+    instance,
+    errors
+  })
+}
+
+module.exports = sendProblem

--- a/src/utils/sendSuccess.js
+++ b/src/utils/sendSuccess.js
@@ -1,0 +1,13 @@
+/**
+ * Standard Success Response  
+ * Params: Response, Data, Message, Status  
+ */
+function sendSuccess(response, data = null, message = 'OK', status = 200) {
+  return response.status(status).json({
+    status,
+    data,
+    message
+  })
+}
+
+module.exports = sendSuccess


### PR DESCRIPTION
### Summary

* Add RFC7807-compliant error response generator (`sendProblem.js`) and universal success response generator (`sendSuccess.js`).

### Details

* Created `src/utils/sendProblem.js` for generating standardized problem details responses, fully referencing error definitions in `errorsMap.js`.
* Created `src/utils/sendSuccess.js` for returning universal API success responses.
* Ensures all API responses (success or error) will be consistent and future-proof according to international standards.

### Usage

* Use `sendProblem(response, status, errorKey, detail, instance, errors)` for all error/exception cases.
* Use `sendSuccess(response, data, message, status)` for normal API success responses.

### Example

```js
sendProblem(res, 422, 'validation', 'Email is invalid.', req.originalUrl, { email: ['Invalid format'] })

sendSuccess(res, { userId: 1 }, 'Registration successful')
```

### Next Step

* Add auto-generated HTML error documentation page middleware in `/src/middleware/errorDocPage.js`.