### PR TITLE
feat(middleware): add HTML error documentation generator :memo:

### DIFF
--- a/src/middleware/errorDocPage.js
+++ b/src/middleware/errorDocPage.js
@@ -1,0 +1,33 @@
+const errorMap = require('../errorsMap')
+
+/**
+ * Generate Error HTML Page  
+ * Params: ErrorKey  
+ */
+function errorDocPage(errorKey) {
+  const err = errorMap[errorKey]
+  if (!(err)) { return null }
+  return `
+  <!DOCTYPE html>
+  <html>
+    <head>
+      <title>${err.title} - ${err.status}</title>
+      <meta charset="utf-8"/>
+      <meta name="viewport" content="width=device-width,initial-scale=1"/>
+      <style>
+        body { font-family: sans-serif; max-width: 500px; margin: 40px auto; }
+        pre { background: #f6f8fa; padding: 12px; border-radius: 4px; }
+      </style>
+    </head>
+    <body>
+      <h1>${err.title} <span style="font-size:16px;color:#888">(${err.status})</span></h1>
+      <p><b>Description:</b> ${err.detail}</p>
+      <p><b>Solution:</b> ${err.solution}</p>
+      <h3>Example Response:</h3>
+      <pre>${JSON.stringify(err.example, null, 2)}</pre>
+    </body>
+  </html>
+  `
+}
+
+module.exports = errorDocPage

--- a/src/middleware/errorDocPage.js
+++ b/src/middleware/errorDocPage.js
@@ -1,17 +1,39 @@
 const errorMap = require('../errorsMap')
 
 /**
+ * Escape HTML Special Characters  
+ * Params: InputString
+ */
+function escapeHtml(inputString) {
+  if (typeof inputString !== 'string') {
+    return ''
+  }
+  const escapeMap = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+  }
+  return inputString.replace(/[&<>"']/g, (char) => {
+    return escapeMap[char]
+  })
+}
+
+/**
  * Generate Error HTML Page  
- * Params: ErrorKey  
+ * Params: ErrorKey
  */
 function errorDocPage(errorKey) {
-  const err = errorMap[errorKey]
-  if (!(err)) { return null }
+  const errorData = errorMap[errorKey]
+  if (!(errorData)) {
+    return null
+  }
   return `
   <!DOCTYPE html>
-  <html>
+  <html lang="en">
     <head>
-      <title>${err.title} - ${err.status}</title>
+      <title>${escapeHtml(errorData.title)} - ${escapeHtml(String(errorData.status))}</title>
       <meta charset="utf-8"/>
       <meta name="viewport" content="width=device-width,initial-scale=1"/>
       <style>
@@ -20,11 +42,11 @@ function errorDocPage(errorKey) {
       </style>
     </head>
     <body>
-      <h1>${err.title} <span style="font-size:16px;color:#888">(${err.status})</span></h1>
-      <p><b>Description:</b> ${err.detail}</p>
-      <p><b>Solution:</b> ${err.solution}</p>
+      <h1>${escapeHtml(errorData.title)} <span style="font-size:16px;color:#888">(${escapeHtml(String(errorData.status))})</span></h1>
+      <p><b>Description:</b> ${escapeHtml(errorData.detail)}</p>
+      <p><b>Solution:</b> ${escapeHtml(errorData.solution)}</p>
       <h3>Example Response:</h3>
-      <pre>${JSON.stringify(err.example, null, 2)}</pre>
+      <pre>${escapeHtml(JSON.stringify(errorData.example, null, 2))}</pre>
     </body>
   </html>
   `


### PR DESCRIPTION
### Summary
- Add HTML error documentation generator middleware (`errorDocPage.js`) for RFC7807 errors.

### Details
- Created `src/middleware/errorDocPage.js`.
- Generates a minimal, readable HTML documentation page for each error defined in `errorsMap.js`.
- Includes error title, status, description, solution, and a full example response.

### Usage
- To generate an error documentation page, call `errorDocPage(errorKey)`.
- Intended to be used in the `/errors/:errorKey` route handler.

### Next Step
- Add API route to serve these error documentation pages (`src/routes/errors.js`).